### PR TITLE
Move quick log snapshot loading off main actor

### DIFF
--- a/AuralystApp/App/MedicationQuickLogFeature.swift
+++ b/AuralystApp/App/MedicationQuickLogFeature.swift
@@ -38,9 +38,7 @@ struct MedicationQuickLogFeature {
                         .loadResponse(
                             TaskResult {
                                 let loader = MedicationQuickLogLoader()
-                                return try await MainActor.run {
-                                    try loader.load(journalID: journalID, on: date)
-                                }
+                                return try loader.load(journalID: journalID, on: date)
                             }
                         )
                     )

--- a/AuralystApp/App/MedicationQuickLogLoader.swift
+++ b/AuralystApp/App/MedicationQuickLogLoader.swift
@@ -15,7 +15,6 @@ struct MedicationQuickLogSnapshot: Equatable {
     )
 }
 
-@MainActor
 struct MedicationQuickLogLoader {
     @Dependency(\.defaultDatabase) private var database
     @Dependency(\.databaseClient) private var databaseClient

--- a/AuralystAppTests/MedicationQuickLogFeatureTests.swift
+++ b/AuralystAppTests/MedicationQuickLogFeatureTests.swift
@@ -49,10 +49,8 @@ struct MedicationQuickLogFeatureTests {
             $0.errorMessage = nil
         }
 
-        let expectedSnapshot = try await MainActor.run {
-            let loader = MedicationQuickLogLoader()
-            return try loader.load(journalID: journal.id, on: testStore.state.selectedDate)
-        }
+        let loader = MedicationQuickLogLoader()
+        let expectedSnapshot = try loader.load(journalID: journal.id, on: testStore.state.selectedDate)
 
         await testStore.receive(\.loadResponse) {
             $0.isLoading = false

--- a/AuralystAppTests/MedicationQuickLogLoaderTests.swift
+++ b/AuralystAppTests/MedicationQuickLogLoaderTests.swift
@@ -44,4 +44,23 @@ struct MedicationQuickLogLoaderSuite {
         #expect(loadedSchedules?.count == 1)
         #expect(loadedSchedules?.first?.label == "Morning")
     }
+
+    @Test("Loads snapshot from a detached task")
+    func loaderRunsOffMainActor() async throws {
+        let result = try await Task.detached {
+            try await withDependencies {
+                $0.context = .test
+                try $0.bootstrapDatabase(configureSyncEngine: false)
+            } operation: {
+                @Dependency(\.databaseClient) var databaseClient
+                let journal = databaseClient.createJournal()
+                let medication = databaseClient.createMedication(journal, "Melatonin", 3, "mg")
+                let loader = MedicationQuickLogLoader()
+                let snapshot = try loader.load(journalID: journal.id, on: Date())
+                return (snapshot, medication.id)
+            }
+        }.value
+
+        #expect(result.0.medications.contains(where: { $0.id == result.1 }))
+    }
 }


### PR DESCRIPTION
## Summary
- remove main-actor hop from quick log snapshot load
- allow loader to run off-main and update tests accordingly
- add detached-task loader test with isolated dependencies

Closes #7.

## Testing
- xcodebuild -project AuralystApp.xcodeproj -scheme AuralystApp -destination 'platform=iOS Simulator,id=86A1B10E-ED24-44E3-ABA2-A63D65D10832' test -only-testing:AuralystAppTests/MedicationQuickLogLoaderSuite -only-testing:AuralystAppTests/MedicationQuickLogFeatureTests COMPILER_INDEX_STORE_ENABLE=NO