### PR TITLE
Fix sync start race

### DIFF
--- a/AuralystApp/App/AppBootstrap.swift
+++ b/AuralystApp/App/AppBootstrap.swift
@@ -28,21 +28,10 @@ struct AppBootstrap {
         }
 
         guard !isRunningTests else { return }
-        Task { await startSyncEngine() }
     }
 }
 
 private extension AppBootstrap {
-    @MainActor
-    static func startSyncEngine() async {
-        @Dependency(\.syncEngine) var syncEngine
-        do {
-            try await syncEngine.start()
-        } catch {
-            // We deliberately ignore bootstrap sync failures so the app can continue launching.
-        }
-    }
-
     static func seedAutomationFixtures(using dependencies: inout DependencyValues) {
         guard let fixture = ProcessInfo.processInfo.environment["AURALYST_UI_FIXTURE"] else { return }
         switch fixture {

--- a/AuralystAppTests/SyncStatusFeatureTests.swift
+++ b/AuralystAppTests/SyncStatusFeatureTests.swift
@@ -118,6 +118,59 @@ struct SyncStatusFeatureTests {
     }
 
     @MainActor
+    @Test("Repeated activation while starting does not start sync twice")
+    func repeatedActivePhaseDoesNotStartTwice() async throws {
+        try prepareTestDependencies()
+
+        let startState = StartCallState()
+        let client = SyncEngineClient(
+            start: {
+                try await withCheckedThrowingContinuation { continuation in
+                    Task { await startState.capture(continuation) }
+                }
+            },
+            stop: {},
+            observeState: {
+                AsyncStream { continuation in
+                    continuation.finish()
+                }
+            }
+        )
+
+        let store = TestStore(
+            initialState: SyncStatusFeature.State(
+                shouldStartSync: true,
+                overridePhaseRaw: nil
+            )
+        ) {
+            SyncStatusFeature()
+        } withDependencies: {
+            $0.syncEngine = client
+        }
+
+        await store.send(.task) {
+            $0.isStarting = true
+            $0.status.phase = .syncing
+            $0.isObserving = true
+        }
+
+        await startState.waitForStartCall()
+
+        await store.send(.scenePhaseChanged(.active))
+
+        let startCount = await startState.getStartCount()
+        #expect(startCount == 1)
+
+        await startState.resumeStartSuccessfully()
+
+        await store.receive(\.startSyncResponse) {
+            $0.isStarting = false
+        }
+
+        await store.finish()
+    }
+
+    @MainActor
     @Test("Background scene phase does not stop the sync engine")
     func backgroundScenePhaseDoesNotStopSyncEngine() async throws {
         try prepareTestDependencies()
@@ -158,6 +211,7 @@ private actor StartCallState {
     private var waiters: [CheckedContinuation<Void, Never>] = []
     private var stopWaiters: [(expected: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private(set) var stopCount = 0
+    private var startCount = 0
     private let thrownError: Error?
 
     init(throws error: Error? = nil) {
@@ -165,6 +219,7 @@ private actor StartCallState {
     }
 
     func capture(_ continuation: CheckedContinuation<Void, Error>) {
+        startCount += 1
         if let thrownError {
             continuation.resume(throwing: thrownError)
             notifyWaiters()
@@ -172,6 +227,10 @@ private actor StartCallState {
         }
         self.continuation = continuation
         notifyWaiters()
+    }
+
+    func getStartCount() -> Int {
+        startCount
     }
 
     func waitForStartCall() async {

--- a/AuralystAppUITests/AuralystAppUITests.swift
+++ b/AuralystAppUITests/AuralystAppUITests.swift
@@ -8,6 +8,7 @@
 import XCTest
 
 final class AuralystAppUITests: XCTestCase {
+    @MainActor
     private func makeApp() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["AURALYST_UI_RESET"] = "1"


### PR DESCRIPTION
## Summary
- Remove bootstrap sync start to centralize lifecycle in SyncStatusFeature.
- Add regression coverage so repeated activation does not start sync twice.
- Mark UI test helper as @MainActor to avoid actor-isolation warnings.

## Testing
- xcodebuild -project AuralystApp.xcodeproj -scheme AuralystApp -destination "platform=iOS Simulator,id=86A1B10E-ED24-44E3-ABA2-A63D65D10832" test COMPILER_INDEX_STORE_ENABLE=NO

Closes #10