### PR TITLE
Fix initial sync overlay when idle

### DIFF
--- a/AuralystApp/App/ContentView.swift
+++ b/AuralystApp/App/ContentView.swift
@@ -98,21 +98,8 @@ struct ContentView: View {
 }
 
 private extension ContentView {
-    enum OverlayState {
-        case syncing
-        case error(message: String)
-    }
-
-    func overlayState(viewStore: ViewStore<AppFeature.State, AppFeature.Action>) -> OverlayState? {
-        guard !viewStore.bypassInitialOverlay, viewStore.hasDeterminedInitialData == false else { return nil }
-        switch viewStore.syncStatus.status.phase {
-        case .syncing:
-            return .syncing
-        case .error(let issue):
-            return .error(message: issue.message)
-        default:
-            return .syncing
-        }
+    func overlayState(viewStore: ViewStore<AppFeature.State, AppFeature.Action>) -> InitialOverlayState? {
+        initialOverlayState(state: viewStore.state)
     }
 
     @ToolbarContentBuilder
@@ -159,7 +146,7 @@ private extension ContentView {
     }
 
     @ViewBuilder
-    func overlayView(for state: OverlayState, viewStore: ViewStore<AppFeature.State, AppFeature.Action>) -> some View {
+    func overlayView(for state: InitialOverlayState, viewStore: ViewStore<AppFeature.State, AppFeature.Action>) -> some View {
         switch state {
         case .syncing:
             ContentUnavailableView {

--- a/AuralystApp/App/InitialOverlayState.swift
+++ b/AuralystApp/App/InitialOverlayState.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum InitialOverlayState: Equatable {
+    case syncing
+    case error(message: String)
+}
+
+func initialOverlayState(state: AppFeature.State) -> InitialOverlayState? {
+    guard !state.bypassInitialOverlay, state.hasDeterminedInitialData == false else { return nil }
+    switch state.syncPhase {
+    case .syncing:
+        return .syncing
+    case .idle where state.shouldStartSync:
+        return .syncing
+    case .error(let issue):
+        return .error(message: issue.message)
+    default:
+        return nil
+    }
+}

--- a/AuralystAppTests/InitialOverlayStateTests.swift
+++ b/AuralystAppTests/InitialOverlayStateTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import AuralystApp
+
+final class InitialOverlayStateTests: XCTestCase {
+    func testIdleWithNoDataReturnsNil() {
+        var state = AppFeature.State(
+            isRunningTests: true,
+            shouldStartSync: false,
+            overridePhaseRaw: nil,
+            bypassInitialOverlay: false
+        )
+        state.hasDeterminedInitialData = false
+        state.syncPhase = .idle
+
+        XCTAssertNil(initialOverlayState(state: state))
+    }
+
+    func testIdleWithShouldStartSyncReturnsSyncing() {
+        var state = AppFeature.State(
+            isRunningTests: true,
+            shouldStartSync: true,
+            overridePhaseRaw: nil,
+            bypassInitialOverlay: false
+        )
+        state.hasDeterminedInitialData = false
+        state.syncPhase = .idle
+
+        XCTAssertEqual(initialOverlayState(state: state), .syncing)
+    }
+
+    func testSyncingReturnsSyncing() {
+        var state = AppFeature.State(
+            isRunningTests: true,
+            shouldStartSync: true,
+            overridePhaseRaw: nil,
+            bypassInitialOverlay: false
+        )
+        state.syncPhase = .syncing
+
+        XCTAssertEqual(initialOverlayState(state: state), .syncing)
+    }
+
+    func testErrorReturnsError() {
+        var state = AppFeature.State(
+            isRunningTests: true,
+            shouldStartSync: true,
+            overridePhaseRaw: nil,
+            bypassInitialOverlay: false
+        )
+        state.syncPhase = .error(SyncIssue(kind: .network, message: "Offline"))
+
+        XCTAssertEqual(initialOverlayState(state: state), .error(message: "Offline"))
+    }
+
+    func testDeterminedDataBypassesOverlay() {
+        var state = AppFeature.State(
+            isRunningTests: true,
+            shouldStartSync: true,
+            overridePhaseRaw: nil,
+            bypassInitialOverlay: false
+        )
+        state.hasDeterminedInitialData = true
+        state.syncPhase = .syncing
+
+        XCTAssertNil(initialOverlayState(state: state))
+    }
+}


### PR DESCRIPTION
## Summary
- show initial overlay only when sync phase is syncing or error
- centralize overlay decision logic for testability
- add unit coverage for idle/syncing/error/determined cases

## Testing
- xcodebuild -project AuralystApp.xcodeproj -scheme AuralystApp -destination 'platform=iOS Simulator,id=86A1B10E-ED24-44E3-ABA2-A63D65D10832' test -only-testing:AuralystAppTests/InitialOverlayStateTests COMPILER_INDEX_STORE_ENABLE=NO

Closes #6