### PR TITLE
Export collaborator notes in CSV/JSON

### DIFF
--- a/AuralystApp/Export/DataExporter.swift
+++ b/AuralystApp/Export/DataExporter.swift
@@ -7,6 +7,7 @@ struct DataExportSummary {
     let exportedMedications: Int
     let exportedSchedules: Int
     let exportedIntakes: Int
+    let exportedCollaboratorNotes: Int
 }
 
 struct DataExporter {
@@ -22,6 +23,7 @@ struct DataExporter {
         lines.append("exportedMedications,\(summary.exportedMedications)")
         lines.append("exportedSchedules,\(summary.exportedSchedules)")
         lines.append("exportedIntakes,\(summary.exportedIntakes)")
+        lines.append("exportedCollaboratorNotes,\(summary.exportedCollaboratorNotes)")
 
         lines.append("")
         lines.append("symptom_entries")
@@ -39,6 +41,20 @@ struct DataExporter {
             values.append(csvEscape(entry.note))
             values.append(csvEscape(entry.sentimentLabel))
             values.append(entry.sentimentScore.map { String($0) } ?? "")
+            lines.append(values.joined(separator: ","))
+        }
+
+        lines.append("")
+        lines.append("collaborator_notes")
+        lines.append("id,journal_id,entry_id,author_name,text,timestamp")
+        for note in dataset.collaboratorNotes {
+            var values: [String] = []
+            values.append(note.id.uuidString)
+            values.append(note.journalID.uuidString)
+            values.append(note.entryID?.uuidString ?? "")
+            values.append(csvEscape(note.authorName))
+            values.append(csvEscape(note.text))
+            values.append(isoFormat.format(note.timestamp))
             lines.append(values.joined(separator: ","))
         }
 
@@ -127,6 +143,7 @@ struct DataExporter {
 private extension DataExporter {
     struct Dataset {
         let entries: [SQLiteSymptomEntry]
+        let collaboratorNotes: [SQLiteCollaboratorNote]
         let medications: [SQLiteMedication]
         let intakes: [SQLiteMedicationIntake]
         let schedules: [SQLiteMedicationSchedule]
@@ -136,7 +153,8 @@ private extension DataExporter {
                 exportedEntries: entries.count,
                 exportedMedications: medications.count,
                 exportedSchedules: schedules.count,
-                exportedIntakes: intakes.count
+                exportedIntakes: intakes.count,
+                exportedCollaboratorNotes: collaboratorNotes.count
             )
         }
     }
@@ -152,6 +170,7 @@ private extension DataExporter {
             let exportedMedications: Int
             let exportedSchedules: Int
             let exportedIntakes: Int
+            let exportedCollaboratorNotes: Int
         }
 
         struct SymptomEntry: Encodable {
@@ -166,6 +185,15 @@ private extension DataExporter {
             let note: String?
             let sentimentLabel: String?
             let sentimentScore: Double?
+        }
+
+        struct CollaboratorNote: Encodable {
+            let id: UUID
+            let journalID: UUID
+            let entryID: UUID?
+            let authorName: String?
+            let text: String?
+            let timestamp: Date
         }
 
         struct Medication: Encodable {
@@ -214,6 +242,7 @@ private extension DataExporter {
         let journal: Journal
         let summary: Summary
         let entries: [SymptomEntry]
+        let collaboratorNotes: [CollaboratorNote]
         let medications: [Medication]
         let intakes: [Intake]
         let schedules: [Schedule]
@@ -224,7 +253,8 @@ private extension DataExporter {
                 exportedEntries: dataset.summary.exportedEntries,
                 exportedMedications: dataset.summary.exportedMedications,
                 exportedSchedules: dataset.summary.exportedSchedules,
-                exportedIntakes: dataset.summary.exportedIntakes
+                exportedIntakes: dataset.summary.exportedIntakes,
+                exportedCollaboratorNotes: dataset.summary.exportedCollaboratorNotes
             )
 
             self.entries = dataset.entries.map { entry in
@@ -240,6 +270,17 @@ private extension DataExporter {
                     note: entry.note,
                     sentimentLabel: entry.sentimentLabel,
                     sentimentScore: entry.sentimentScore
+                )
+            }
+
+            self.collaboratorNotes = dataset.collaboratorNotes.map { note in
+                CollaboratorNote(
+                    id: note.id,
+                    journalID: note.journalID,
+                    entryID: note.entryID,
+                    authorName: note.authorName,
+                    text: note.text,
+                    timestamp: note.timestamp
                 )
             }
 
@@ -302,6 +343,11 @@ private extension DataExporter {
                 .order { $0.timestamp.desc() }
                 .fetchAll(db)
 
+            let collaboratorNotes = try SQLiteCollaboratorNote
+                .where { $0.journalID == journal.id }
+                .order { $0.timestamp.desc() }
+                .fetchAll(db)
+
             let medications = try SQLiteMedication
                 .where { $0.journalID == journal.id }
                 .order { $0.name.asc() }
@@ -329,7 +375,13 @@ private extension DataExporter {
                 .order { $0.sortOrder.asc() }
                 .fetchAll(db)
 
-            return Dataset(entries: entries, medications: medications, intakes: intakes, schedules: schedules)
+            return Dataset(
+                entries: entries,
+                collaboratorNotes: collaboratorNotes,
+                medications: medications,
+                intakes: intakes,
+                schedules: schedules
+            )
         }
     }
 

--- a/AuralystAppTests/DataExporterTests.swift
+++ b/AuralystAppTests/DataExporterTests.swift
@@ -20,6 +20,12 @@ struct DataExporterSuite {
             timestamp: Date(timeIntervalSince1970: 1_726_601_200),
             isMenstruating: true
         )
+        _ = try store.createCollaboratorNote(
+            for: journal,
+            entry: entry,
+            authorName: "Alex",
+            text: "Shared context"
+        )
 
         let medication = store.createMedication(for: journal, name: "Ibuprofen", defaultAmount: 200, defaultUnit: "mg")
         _ = try store.createMedicationIntake(for: medication, amount: 1, unit: "tablet")
@@ -45,6 +51,7 @@ struct DataExporterSuite {
         #expect(summary.exportedMedications == 1)
         #expect(summary.exportedSchedules == 1)
         #expect(summary.exportedIntakes == 1)
+        #expect(summary.exportedCollaboratorNotes == 1)
 
         // Sanity check: ensure entry persisted for later export operations
         #expect(entry.id != UUID())
@@ -62,16 +69,23 @@ struct DataExporterSuite {
             severity: 4,
             note: "Morning log"
         )
+        _ = try store.createCollaboratorNote(
+            for: journal,
+            authorName: "Jamie",
+            text: "Follow-up"
+        )
         let medication = store.createMedication(for: journal, name: "Vitamin D", defaultAmount: 1, defaultUnit: "capsule")
         _ = try store.createMedicationIntake(for: medication, amount: 1, unit: "capsule")
 
         let jsonData = try DataExporter.exportJSON(for: journal)
         let object = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
         let entries = object? ["entries"] as? [[String: Any]]
+        let collaboratorNotes = object? ["collaboratorNotes"] as? [[String: Any]]
         let meds = object? ["medications"] as? [[String: Any]]
         let summary = object? ["summary"] as? [String: Any]
 
         #expect(entries?.count == 1)
+        #expect(collaboratorNotes?.count == 1)
         #expect(meds?.count == 1)
         #expect((summary? ["exportedEntries"] as? Int) == 1)
     }
@@ -88,6 +102,11 @@ struct DataExporterSuite {
             severity: 8,
             note: "Severe headache"
         )
+        _ = try store.createCollaboratorNote(
+            for: journal,
+            authorName: "Pat",
+            text: "Context note"
+        )
 
         let csvData = try DataExporter.exportCSV(for: journal)
         guard let csvString = String(data: csvData, encoding: .utf8) else {
@@ -97,7 +116,9 @@ struct DataExporterSuite {
 
         #expect(csvString.contains("Entries"))
         #expect(csvString.contains("symptom_entries"))
+        #expect(csvString.contains("collaborator_notes"))
         #expect(csvString.contains("Severe headache"))
+        #expect(csvString.contains("Context note"))
     }
 
     @MainActor
@@ -109,8 +130,19 @@ struct DataExporterSuite {
         let journalA = store.createJournal()
         let journalB = store.createJournal()
 
-        _ = try store.createSymptomEntry(for: journalA, severity: 2)
+        let entryA = try store.createSymptomEntry(for: journalA, severity: 2)
         _ = try store.createSymptomEntry(for: journalB, severity: 9)
+        _ = try store.createCollaboratorNote(
+            for: journalA,
+            entry: entryA,
+            authorName: "Casey",
+            text: "Journal A note"
+        )
+        _ = try store.createCollaboratorNote(
+            for: journalB,
+            authorName: "Taylor",
+            text: "Journal B note"
+        )
 
         let medicationA = store.createMedication(for: journalA, name: "Aspirin", defaultAmount: 1, defaultUnit: "tablet")
         let medicationB = store.createMedication(for: journalB, name: "Magnesium", defaultAmount: 2, defaultUnit: "capsule")
@@ -153,6 +185,7 @@ struct DataExporterSuite {
         #expect(summary.exportedMedications == 1)
         #expect(summary.exportedSchedules == 1)
         #expect(summary.exportedIntakes == 1)
+        #expect(summary.exportedCollaboratorNotes == 1)
     }
 
     @MainActor
@@ -170,6 +203,17 @@ struct DataExporterSuite {
         _ = try store.createMedicationIntake(for: medicationA, amount: 1, unit: "tablet")
         _ = try store.createMedicationIntake(for: medicationA, amount: 2, unit: "tablet")
         _ = try store.createMedicationIntake(for: medicationB, amount: 1, unit: "tablet")
+
+        _ = try store.createCollaboratorNote(
+            for: journalA,
+            authorName: "Morgan",
+            text: "Journal A note"
+        )
+        _ = try store.createCollaboratorNote(
+            for: journalB,
+            authorName: "Riley",
+            text: "Journal B note"
+        )
 
         @Dependency(\.defaultDatabase) var database
         let scheduleA = SQLiteMedicationSchedule(
@@ -205,11 +249,14 @@ struct DataExporterSuite {
         let object = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
         let intakes = object? ["intakes"] as? [[String: Any]]
         let schedules = object? ["schedules"] as? [[String: Any]]
+        let collaboratorNotes = object? ["collaboratorNotes"] as? [[String: Any]]
         let summary = object? ["summary"] as? [String: Any]
 
         #expect(intakes?.count == 2)
         #expect(schedules?.count == 1)
+        #expect(collaboratorNotes?.count == 1)
         #expect((summary? ["exportedIntakes"] as? Int) == 2)
         #expect((summary? ["exportedSchedules"] as? Int) == 1)
+        #expect((summary? ["exportedCollaboratorNotes"] as? Int) == 1)
     }
 }


### PR DESCRIPTION
## Summary
- include collaborator notes in export dataset, CSV section, and JSON payload
- add collaborator note count to export summary
- expand DataExporter tests for collaborator note content and filtering

## Testing
- xcodebuild -project AuralystApp.xcodeproj -scheme AuralystApp -destination 'platform=iOS Simulator,id=86A1B10E-ED24-44E3-ABA2-A63D65D10832' -only-testing:AuralystAppTests/DataExporterSuite test COMPILER_INDEX_STORE_ENABLE=NO

Closes #4