### PR TITLE
Fix quick log refresh churn

### DIFF
--- a/AuralystApp/App/JournalEntriesView.swift
+++ b/AuralystApp/App/JournalEntriesView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 @preconcurrency import SQLiteData
-import Dependencies
 import ComposableArchitecture
 
 struct JournalEntriesView: View {
@@ -8,6 +7,7 @@ struct JournalEntriesView: View {
     let onAddEntry: () -> Void
     let onShare: () -> Void
     let onExport: () -> Void
+    @StateObject private var quickLogStore: StoreOf<MedicationQuickLogFeature>
 
     // Fetch entries and models for this specific journal
     @FetchAll var entries: [SQLiteSymptomEntry]
@@ -47,6 +47,11 @@ struct JournalEntriesView: View {
         self.onAddEntry = onAddEntry
         self.onShare = onShare
         self.onExport = onExport
+        self._quickLogStore = StateObject(
+            wrappedValue: Store(initialState: MedicationQuickLogFeature.State(journalID: journal.id)) {
+                MedicationQuickLogFeature()
+            }
+        )
 
         // Filter entries and medications for this journal
         self._entries = FetchAll(SQLiteSymptomEntry.where { $0.journalID == journal.id })
@@ -66,9 +71,7 @@ struct JournalEntriesView: View {
         List {
             // Quick log meds from home
             MedicationQuickLogSection(
-                store: Store(initialState: MedicationQuickLogFeature.State(journalID: journal.id)) {
-                    MedicationQuickLogFeature()
-                },
+                store: quickLogStore,
                 manageAction: { activeSheet = .medicationManager },
                 loggingError: nil,
                 presentAsNeeded: { medication, date in
@@ -102,6 +105,12 @@ struct JournalEntriesView: View {
                     }
                 }
             }
+        }
+        .onChange(of: medications) { _, _ in
+            quickLogStore.send(.refreshRequested)
+        }
+        .onChange(of: medicationIntakes) { _, _ in
+            quickLogStore.send(.refreshRequested)
         }
         .navigationTitle("Journal")
         .toolbar {
@@ -314,34 +323,12 @@ private struct DayDetailView: View {
         .inlineNavigationTitleDisplay()
         .onAppear {
             currentIntakes = intakes
-            refreshIntakes()
         }
-        .onReceive(NotificationCenter.default.publisher(for: .medicationIntakesDidChange)) { _ in
-            refreshIntakes()
-        }
-    }
-
-    private func refreshIntakes() {
-        @Dependency(\.defaultDatabase) var database
-        let bounds = dayBounds(for: date)
-        do {
-            let fetched = try database.read { db in
-                try SQLiteMedicationIntake
-                    .where { $0.timestamp >= bounds.start && $0.timestamp < bounds.end }
-                    .fetchAll(db)
-            }
-            currentIntakes = fetched
-        } catch {
-            currentIntakes = intakes
+        .onChange(of: intakes) { _, newValue in
+            currentIntakes = newValue
         }
     }
 
-    private func dayBounds(for date: Date) -> (start: Date, end: Date) {
-        let calendar = Calendar.current
-        let start = calendar.startOfDay(for: date)
-        let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start
-        return (start, end)
-    }
 }
 
 private struct SymptomEntryEditorView: View {

--- a/AuralystApp/App/MedicationQuickLogFeature.swift
+++ b/AuralystApp/App/MedicationQuickLogFeature.swift
@@ -4,6 +4,8 @@ import Foundation
 
 @Reducer
 struct MedicationQuickLogFeature {
+    @Dependency(\.continuousClock) var clock
+
     @ObservableState
     struct State: Equatable {
         var journalID: UUID
@@ -21,6 +23,7 @@ struct MedicationQuickLogFeature {
     enum Action {
         case task
         case refresh
+        case refreshRequested
         case selectedDateChanged(Date)
         case loadResponse(TaskResult<MedicationQuickLogSnapshot>)
     }
@@ -44,6 +47,13 @@ struct MedicationQuickLogFeature {
                     )
                 }
 
+            case .refreshRequested:
+                return .run { [clock] send in
+                    try? await clock.sleep(for: .milliseconds(250))
+                    await send(.refresh)
+                }
+                .cancellable(id: RefreshDebounceID.refresh, cancelInFlight: true)
+
             case .selectedDateChanged(let date):
                 state.selectedDate = Calendar.current.startOfDay(for: date)
                 return .send(.refresh)
@@ -60,4 +70,8 @@ struct MedicationQuickLogFeature {
             }
         }
     }
+}
+
+private enum RefreshDebounceID: Hashable {
+    case refresh
 }

--- a/AuralystApp/App/MedicationQuickLogSection.swift
+++ b/AuralystApp/App/MedicationQuickLogSection.swift
@@ -44,14 +44,14 @@ struct MedicationQuickLogSection: View {
                                                     schedule: sched,
                                                     medication: med,
                                                     selectedDate: viewStore.selectedDate,
-                                                    onRefresh: { viewStore.send(.refresh) }
+                                                    onRefresh: { viewStore.send(.refreshRequested) }
                                                 )
                                             } else {
                                                 unlogScheduledDose(
                                                     schedule: sched,
                                                     selectedDate: viewStore.selectedDate,
                                                     snapshot: viewStore.snapshot,
-                                                    onRefresh: { viewStore.send(.refresh) }
+                                                    onRefresh: { viewStore.send(.refreshRequested) }
                                                 )
                                             }
                                         }
@@ -96,12 +96,6 @@ struct MedicationQuickLogSection: View {
                 }
             }
             .task { viewStore.send(.task) }
-            .onReceive(NotificationCenter.default.publisher(for: .medicationsDidChange)) { _ in
-                viewStore.send(.refresh)
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .medicationIntakesDidChange)) { _ in
-                viewStore.send(.refresh)
-            }
         }
     }
 

--- a/AuralystAppTests/MedicationQuickLogFeatureTests.swift
+++ b/AuralystAppTests/MedicationQuickLogFeatureTests.swift
@@ -60,4 +60,43 @@ struct MedicationQuickLogFeatureTests {
         #expect(testStore.state.snapshot.medications.contains(where: { $0.name == "Vitamin D" }))
         #expect(testStore.state.snapshot.schedulesByMedication[medication.id]?.contains(where: { $0.id == schedule.id }) == true)
     }
+
+    @MainActor
+    @Test("Debounces refresh requests to a single load")
+    func debouncesRefreshRequests() async throws {
+        try prepareTestDependencies()
+
+        let store = DataStore()
+        let journal = store.createJournal()
+        _ = store.createMedication(
+            for: journal,
+            name: "Vitamin D",
+            defaultAmount: 1,
+            defaultUnit: "pill"
+        )
+
+        let testStore = TestStore(
+            initialState: MedicationQuickLogFeature.State(journalID: journal.id)
+        ) {
+            MedicationQuickLogFeature()
+        }
+
+        await testStore.send(.refreshRequested)
+        await testStore.send(.refreshRequested)
+
+        await testStore.receive(\.refresh) {
+            $0.isLoading = true
+            $0.errorMessage = nil
+        }
+
+        let loader = MedicationQuickLogLoader()
+        let expectedSnapshot = try loader.load(journalID: journal.id, on: testStore.state.selectedDate)
+
+        await testStore.receive(\.loadResponse) {
+            $0.isLoading = false
+            $0.snapshot = expectedSnapshot
+        }
+
+        await testStore.finish()
+    }
 }

--- a/AuralystAppTests/TestDependencyBootstrapTests.swift
+++ b/AuralystAppTests/TestDependencyBootstrapTests.swift
@@ -76,6 +76,7 @@ func prepareTestDependencies(_ configure: (inout DependencyValues) throws -> Voi
     try prepareDependencies {
         try $0.bootstrapDatabase(configureSyncEngine: true)
         $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+        $0.continuousClock = ContinuousClock()
         $0.syncEngine = SyncEngineClient(
             start: {},
             stop: {},


### PR DESCRIPTION
## Summary
- remove NotificationCenter refresh overlap and rely on @FetchAll changes
- debounce quick log refresh requests in MedicationQuickLogFeature
- update day detail intake refresh to follow @FetchAll updates
- add quick log debounce test and set continuousClock in test bootstrap

## Testing
- xcodebuild -project AuralystApp.xcodeproj -scheme AuralystApp -destination "platform=iOS Simulator,id=86A1B10E-ED24-44E3-ABA2-A63D65D10832" test COMPILER_INDEX_STORE_ENABLE=NO

Closes #11