### PR TITLE
Fix Add Entry save dismissal

### DIFF
--- a/AuralystApp/App/AppBootstrap.swift
+++ b/AuralystApp/App/AppBootstrap.swift
@@ -35,6 +35,8 @@ private extension AppBootstrap {
     static func seedAutomationFixtures(using dependencies: inout DependencyValues) {
         guard let fixture = ProcessInfo.processInfo.environment["AURALYST_UI_FIXTURE"] else { return }
         switch fixture {
+        case "journal_only":
+            seedJournalOnlyFixture(using: &dependencies)
         case "as_needed_quicklog":
             seedAsNeededFixture(using: &dependencies)
         case "quicklog_initial":
@@ -53,6 +55,19 @@ private extension AppBootstrap {
             }
         } catch {
             // Best-effort cleanup for UI automation.
+        }
+    }
+
+    static func seedJournalOnlyFixture(using dependencies: inout DependencyValues) {
+        do {
+            let database = dependencies.defaultDatabase
+            try database.write { db in
+                guard try SQLiteJournal.all.fetchAll(db).isEmpty else { return }
+                let journal = SQLiteJournal()
+                try SQLiteJournal.insert { journal }.execute(db)
+            }
+        } catch {
+            // Only used for automation fixtures; ignore failures in production builds.
         }
     }
 

--- a/AuralystApp/App/ContentView.swift
+++ b/AuralystApp/App/ContentView.swift
@@ -10,6 +10,7 @@ struct ContentView: View {
     @FetchAll var journals: [SQLiteJournal]
     @FetchOne var primaryJournal: SQLiteJournal?
     @FetchAll var entries: [SQLiteSymptomEntry]
+    @State private var addEntryStore: StoreOf<AddEntryFeature>?
 
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
@@ -32,6 +33,10 @@ struct ContentView: View {
             }
             .onChange(of: journals.isEmpty) { _, _ in viewStore.send(.journalsChanged(isEmpty: journals.isEmpty)) }
             .onChange(of: entries.count) { _, _ in viewStore.send(.entriesCountChanged(entries.count)) }
+            .onChange(of: viewStore.showingAddEntry) { _, isPresented in
+                guard !isPresented else { return }
+                addEntryStore = nil
+            }
             .onChange(of: viewStore.syncStatus.status.phase) { _, phase in
                 viewStore.send(.syncPhaseChanged(phase))
             }
@@ -42,11 +47,17 @@ struct ContentView: View {
                 )
             ) {
                 if let journal = primaryJournal {
-                    AddEntryView(
-                        store: Store(initialState: AddEntryFeature.State(journalID: journal.id)) {
+                    if let store = addEntryStore {
+                        AddEntryView(store: store)
+                    } else {
+                        let store = Store(initialState: AddEntryFeature.State(journalID: journal.id)) {
                             AddEntryFeature()
                         }
-                    )
+                        AddEntryView(store: store)
+                            .onAppear {
+                                addEntryStore = store
+                            }
+                    }
                 }
             }
             .sheet(

--- a/AuralystAppTests/MedicationQuickLogLoaderTests.swift
+++ b/AuralystAppTests/MedicationQuickLogLoaderTests.swift
@@ -49,7 +49,7 @@ struct MedicationQuickLogLoaderSuite {
     @Test("Loads snapshot from a detached task")
     func loaderRunsOffMainActor() async throws {
         let result = try await Task.detached {
-            try await withDependencies {
+            try withDependencies {
                 $0.context = .test
                 try $0.bootstrapDatabase(configureSyncEngine: false)
             } operation: {

--- a/AuralystAppUITests/AuralystAppUITests.swift
+++ b/AuralystAppUITests/AuralystAppUITests.swift
@@ -56,6 +56,28 @@ final class AuralystAppUITests: XCTestCase {
     }
 
     @MainActor
+    func testAddEntrySavesAndDismisses() throws {
+        let app = makeApp(fixture: "journal_only")
+        app.launch()
+
+        let addEntryButton = app.buttons["Add Entry"]
+        XCTAssertTrue(addEntryButton.waitForExistence(timeout: 5))
+        addEntryButton.tap()
+
+        let newEntryNav = app.navigationBars["New Entry"]
+        XCTAssertTrue(newEntryNav.waitForExistence(timeout: 5))
+
+        let saveButton = app.buttons["Save"]
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 5))
+        saveButton.tap()
+
+        XCTAssertFalse(
+            newEntryNav.waitForExistence(timeout: 2),
+            "Expected Add Entry sheet to dismiss after saving."
+        )
+    }
+
+    @MainActor
     func testLaunchPerformance() throws {
         guard ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"] != nil else {
             throw XCTSkip("Performance launch test runs only on simulator.")


### PR DESCRIPTION
## Summary
- keep the Add Entry store stable while the sheet is open so save state/dismissal isn't lost
- add a journal-only UI fixture for deterministic Add Entry tests
- add UI coverage for Save -> dismiss
- remove an unnecessary await in MedicationQuickLogLoaderTests

## Testing
- xcodebuild -project AuralystApp.xcodeproj -scheme AuralystApp -destination 'platform=iOS Simulator,id=86A1B10E-ED24-44E3-ABA2-A63D65D10832' -only-testing:AuralystAppUITests/AuralystAppUITests test COMPILER_INDEX_STORE_ENABLE=NO
