### PR TITLE
Fix ensureJournalCloudMetadata not recreating deleted metadata

### DIFF
--- a/AuralystApp/Persistence/DatabaseClientCloudMetadata.swift
+++ b/AuralystApp/Persistence/DatabaseClientCloudMetadata.swift
@@ -72,24 +72,48 @@ private func ensureMetadataInTransaction(
         )
     }
 
+    try insertMetadataRow(
+        journalID: journalID, db: db
+    )
+}
+
+private func insertMetadataRow(
+    journalID: UUID, db: Database
+) throws {
     try db.execute(
         sql: """
-            UPDATE sqLiteJournal
-            SET createdAt = createdAt WHERE id = ?
+            INSERT INTO sqlitedata_icloud_metadata
+                (recordPrimaryKey, recordType, zoneName, ownerName,
+                 userModificationTime, _isDeleted)
+            VALUES (
+                ?, ?,
+                COALESCE(
+                    (SELECT zoneName FROM sqlitedata_icloud_metadata LIMIT 1),
+                    'co.pointfree.SQLiteData.defaultZone'
+                ),
+                COALESCE(
+                    (SELECT ownerName FROM sqlitedata_icloud_metadata LIMIT 1),
+                    '__defaultOwner__'
+                ),
+                CAST(strftime('%s', 'now') AS INTEGER),
+                0
+            )
+            ON CONFLICT DO NOTHING
             """,
-        arguments: [journalID.uuidString]
+        arguments: [journalID.uuidString, SQLiteJournal.tableName]
     )
 }
 
 private func iCloudMetadataTableExists(in db: Database) throws -> Bool {
-    try String.fetchOne(
+    try Bool.fetchOne(
         db,
         sql: """
-            SELECT name FROM sqlite_master
-            WHERE type = 'table'
-            AND name = 'sqlitedata_icloud_metadata'
+            SELECT EXISTS(
+                SELECT 1 FROM pragma_table_list
+                WHERE name = 'sqlitedata_icloud_metadata'
+            )
         """
-    ) != nil
+    ) ?? false
 }
 
 private func evaluateMetadataRow(

--- a/AuralystAppTests/DataStoreTests.swift
+++ b/AuralystAppTests/DataStoreTests.swift
@@ -35,15 +35,11 @@ struct DataStoreSuite {
 // The SyncEngine's complex triggers corrupt the Swift runtime's generic metadata
 // caches when deallocated, so this test must not share a serialized suite with
 // tests that run after SyncEngine cleanup.
-@Suite("CloudKit metadata bug repro")
-struct CloudKitMetadataBugSuite {
-    // BUG: ensureJournalCloudMetadata does a no-op UPDATE
-    // hoping the SQLiteData trigger recreates metadata, but
-    // it doesn't. When fixed, flip assertion to #expect(has).
-    // See: https://github.com/beforetheshoes/Auralyst/issues/43
+@Suite("CloudKit metadata restoration")
+struct CloudKitMetadataRestorationSuite {
     @MainActor
-    @Test("Deleted journal metadata is not yet restored")
-    func deletedMetadataIsNotRestoredYet() throws {
+    @Test("Deleted journal metadata is restored by ensureJournalCloudMetadata")
+    func deletedMetadataIsRestored() throws {
         try prepareTestDependencies(
             configureSyncEngine: true
         )
@@ -88,10 +84,7 @@ struct CloudKitMetadataBugSuite {
             ) ?? false
         }
 
-        // This asserts current (broken) behavior.
-        // When #43 is fixed, this will fail — change to:
-        // #expect(hasMetadata)
-        #expect(!hasMetadata)
+        #expect(hasMetadata)
     }
 }
 


### PR DESCRIPTION
## Summary
Closes #43

- Fixed `iCloudMetadataTableExists` checking only `sqlite_master` (main schema), missing the metadata table in the attached `sqlitedata_icloud` schema. Now uses `pragma_table_list` which searches all schemas.
- Replaced the no-op `UPDATE sqLiteJournal SET createdAt = createdAt` with a direct `INSERT INTO sqlitedata_icloud_metadata` that provides all required columns, bypassing the need for SQLiteData's temporary per-connection triggers.

## Test plan
- [x] Flipped existing `deletedMetadataIsNotRestoredYet` test to assert metadata IS restored (red), then made it green
- [x] All 93 unit tests pass
- [x] UI tests pass (pre-push hook)
- [x] SwiftLint: 0 violations